### PR TITLE
Don't use a ThreadGroup for tracking worker threads

### DIFF
--- a/lib/mongrel/handlers.rb
+++ b/lib/mongrel/handlers.rb
@@ -351,7 +351,7 @@ module Mongrel
 
     def process(request, response)
       if rand(@sample_rate)+1 == @sample_rate
-        @processors.sample(listener.workers.list.length)
+        @processors.sample(listener.workers.length)
         @headcount.sample(request.params.length)
         @reqsize.sample(request.body.length / 1024.0)
         @respsize.sample((response.body.length + response.header.out.length) / 1024.0)


### PR DESCRIPTION
Mongrel current uses a ThreadGroup to track its worker threads.  But this has the unintended side-effect that any thread spawned by a request will inherit the group of the request thread.  Thus, mongrel will think these new threads are requests and take them into account when it enforces num_process restrictions.  This mostly went unnoticed for us in 1.1.3 but after upgrading 1.1.5 the num_process enforcement fix caused mongrels to start rejecting requests after we spawned a background thread pool.

I've fixed this by tracking threads in an array and then purging any completed threads whenever this array is accessed.  This is not ideal, but I think any other fix would require the thread removing itself from the list of workers and thus require a mutex.  Using an array seemed like the most straight-forward fix.
