### PR TITLE
Found typo in line 108

### DIFF
--- a/lib/mongrel/cgi.rb
+++ b/lib/mongrel/cgi.rb
@@ -105,7 +105,7 @@ module Mongrel
         when Hash
           cookie.each_value {|c| to['Set-Cookie'] = c.to_s}
         else
-          to['Set-Cookie'] = head['cookie'].to_s
+          to['Set-Cookie'] = @head['cookie'].to_s
         end
         
         @head.delete('cookie')


### PR DESCRIPTION
  *\* I fixing typo in variable "@ head" line 108 :

 108         to['Set-Cookie'] = head['cookie'].to_s 

to

 108        to['Set-Cookie'] = @head['cookie'].to_s
